### PR TITLE
Fix errors in multi3drefer metric

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
     ],
-    install_requires=["torchmetrics", "torch", "huggingface_hub", "datasets", "scipy", "gdown"]
+    install_requires=["torchmetrics", "torch", "huggingface_hub", "datasets", "scipy", "gdown"],
+    extras_require={
+        "dev": ["pytest"]
+    },
 )

--- a/src/torchmetrics_ext/metrics/visual_grounding/multi3drefer.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/multi3drefer.py
@@ -65,10 +65,10 @@ class Multi3DReferMetric(Metric):
 
             for iou_threshold in self.iou_thresholds:
                 self.add_state(
-                    name=f"{eval_type}_f1_thresh_{iou_threshold}", default=torch.tensor(0), dist_reduce_fx="sum"
+                    name=f"{eval_type}_f1_thresh_{iou_threshold}", default=torch.tensor(0.), dist_reduce_fx="sum"
                 )
         for iou_threshold in self.iou_thresholds:
-            self.add_state(name=f"all_f1_thresh_{iou_threshold}", default=torch.tensor(0), dist_reduce_fx="sum")
+            self.add_state(name=f"all_f1_thresh_{iou_threshold}", default=torch.tensor(0.), dist_reduce_fx="sum")
 
         self.add_state(name="all_total", default=torch.tensor(0), dist_reduce_fx="sum")
 
@@ -166,12 +166,14 @@ class Multi3DReferMetric(Metric):
     def compute(self) -> Dict[str, torch.Tensor]:
         output_dict = {}
         for iou_threshold in self.iou_thresholds:
-            for eval_type in self.eval_type:
+            for eval_type in self.eval_types:
                 output_dict[f"{eval_type}_{iou_threshold}"] = self.__dict__[f"{eval_type}_f1_thresh_{iou_threshold}"] / self.__dict__[f"{eval_type}_total"]
             output_dict[f"all_{iou_threshold}"] = self.__dict__[f"all_f1_thresh_{iou_threshold}"] / self.all_total
 
         # clean the zt case since it doesn't have thresholds
-        output_dict[f"zt_w_d_f1"] = output_dict["zt_w_d_f1_thresh_0.25"]
-        del output_dict["zt_w_d_f1_thresh_0.5"]
-        del output_dict["zt_w_d_f1_thresh_0.25"]
+        output_dict[f"zt_w_d"] = output_dict["zt_w_d_0.25"]
+        del output_dict["zt_w_d_0.5"]
+        del output_dict["zt_w_d_0.25"]
+        del output_dict["zt_wo_d_0.5"]
+        del output_dict["zt_wo_d_0.25"]
         return output_dict

--- a/src/torchmetrics_ext/metrics/visual_grounding/multi3drefer.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/multi3drefer.py
@@ -172,6 +172,7 @@ class Multi3DReferMetric(Metric):
 
         # clean the zt case since it doesn't have thresholds
         output_dict[f"zt_w_d"] = output_dict["zt_w_d_0.25"]
+        output_dict[f"zt_wo_d"] = output_dict["zt_wo_d_0.25"]
         del output_dict["zt_w_d_0.5"]
         del output_dict["zt_w_d_0.25"]
         del output_dict["zt_wo_d_0.5"]

--- a/src/torchmetrics_ext/metrics/visual_grounding/multi3drefer.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/multi3drefer.py
@@ -166,7 +166,7 @@ class Multi3DReferMetric(Metric):
     def compute(self) -> Dict[str, torch.Tensor]:
         output_dict = {}
         for iou_threshold in self.iou_thresholds:
-            for eval_type in self.eval_types:
+            for eval_type in Multi3DReferMetric.eval_types:
                 output_dict[f"{eval_type}_{iou_threshold}"] = self.__dict__[f"{eval_type}_f1_thresh_{iou_threshold}"] / self.__dict__[f"{eval_type}_total"]
             output_dict[f"all_{iou_threshold}"] = self.__dict__[f"all_f1_thresh_{iou_threshold}"] / self.all_total
 

--- a/test/test_multi3drefer.py
+++ b/test/test_multi3drefer.py
@@ -1,0 +1,150 @@
+import pytest
+import torch
+from torchmetrics_ext.metrics.visual_grounding import Multi3DReferMetric
+
+
+# Test for Multi3DReferMetric
+@pytest.fixture
+def multi3drefer_metric():
+    return Multi3DReferMetric(split="validation")
+
+
+def test_multi3drefer_metric_low_iou(multi3drefer_metric):
+    multi3drefer_metric.reset()  # Reset the metric before testing
+
+    # Test update functionality with dummy data
+    preds = {
+        "scene0406_00_6": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 0 predicted boxes
+        "scene0406_00_0": torch.tensor([[[3.83, 3.04, 4.26], [3.88, 3.47, 4.78]]]),  # 1 predicted box
+        "scene0406_00_84": torch.tensor([[[3.40, 3.89, 3.31], [3.71, 3.96, 3.58]]]),  # 1 predicted box
+        "scene0406_00_10": torch.tensor([
+            [
+                [
+                    -3.01,
+                    -3.26,
+                    3.034
+                ],
+                [
+                    -2.54,
+                    -3.03,
+                    4.91
+                ]
+            ],
+            [
+                [
+                    -3.43,
+                    -3.32,
+                    4.23
+                ],
+                [
+                    -2.96,
+                    -2.89,
+                    4.71
+                ]
+            ]
+        ])
+    }
+    result = multi3drefer_metric(preds)
+    assert result["zt_w_d"].item() == 0.0
+    assert result["st_w_d_0.25"].item() == 0.0
+    assert result["st_wo_d_0.25"].item() == 0.0
+    assert result["st_w_d_0.5"].item() == 0.0
+    assert result["st_wo_d_0.5"].item() == 0.0
+    assert result["mt_0.25"].item() == 0.0
+    assert result["mt_0.5"].item() == 0.0
+    assert result["all_0.25"].item() == 0.0
+    assert result["all_0.5"].item() == 0.0
+
+
+def test_multi3drefer_metric_medium_iou(multi3drefer_metric):
+    multi3drefer_metric.reset()  # Reset the metric before testing
+
+    # Test update functionality with dummy data
+    preds = {
+        "scene0406_00_6": torch.tensor([]),  # 0 predicted boxes
+        "scene0406_00_0": torch.tensor([[[0.855, 0.0380, 1.2593], [0.88, 0.47, 1.78]]]),  # 1 predicted box
+        "scene0406_00_84": torch.tensor([[[0.0827, 0.8602, 0.3036], [0.706, 0.964, 0.575]]]),  # 1 predicted box
+        "scene0406_00_10": torch.tensor([
+            [
+                [
+                    -0.2018,
+                    -0.3002,
+                    0.0238
+                ],
+                [
+                    0.46,
+                    0.03,
+                    1.91
+                ]
+            ],
+            [
+                [
+                    -0.43,
+                    -0.32,
+                    1.525
+                ],
+                [
+                    0.04,
+                    -0.11,
+                    1.71
+                ]
+            ]
+        ])
+    }
+    result = multi3drefer_metric(preds)
+    assert result["zt_w_d"].item() == 1.0
+    assert result["st_w_d_0.25"].item() == 1.0
+    assert result["st_wo_d_0.25"].item() == 1.0
+    assert result["st_w_d_0.5"].item() == 0.0
+    assert result["st_wo_d_0.5"].item() == 0.0
+    assert result["mt_0.25"].item() == 1.0
+    assert result["mt_0.5"].item() == 0.0
+    assert result["all_0.25"].item() == 1.0
+    assert result["all_0.5"].item() == 0.25  # because zt counts as 1
+
+
+def test_multi3drefer_metric_high_iou(multi3drefer_metric):
+    multi3drefer_metric.reset()  # Reset the metric before testing
+
+    # Test update functionality with dummy data
+    preds = {
+        "scene0406_00_6": torch.tensor([]),  # 0 predicted boxes
+        "scene0406_00_0": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 1 predicted box
+        "scene0406_00_84": torch.tensor([[[0.40, 0.89, 0.31], [0.71, 0.96, 0.58]]]),  # 1 predicted box
+        "scene0406_00_10": torch.tensor([
+            [
+                [
+                    -0.01,
+                    -0.26,
+                    0.034
+                ],
+                [
+                    0.46,
+                    -0.03,
+                    1.91
+                ]
+            ],
+            [
+                [
+                    -0.43,
+                    -0.32,
+                    1.23
+                ],
+                [
+                    0.04,
+                    -0.11,
+                    1.71
+                ]
+            ]
+        ])
+    }
+    result = multi3drefer_metric(preds)
+    assert result["zt_w_d"].item() == 1.0
+    assert result["st_w_d_0.25"].item() == 1.0
+    assert result["st_wo_d_0.25"].item() == 1.0
+    assert result["st_w_d_0.5"].item() == 1.0
+    assert result["st_wo_d_0.5"].item() == 1.0
+    assert result["mt_0.25"].item() == 1.0
+    assert result["mt_0.5"].item() == 1.0
+    assert result["all_0.25"].item() == 1.0
+    assert result["all_0.5"].item() == 1.0


### PR DESCRIPTION
# Change Log

- Change f1 thresh states to `float`s instead of `long`s
- Correct `self.eval_type` to `self.eval_types`
- Correct logic at end of `compute()` for removing unnecessary `zt_*` metrics
- Added a base set of tests for `Multi3DReferMetric`

The final set of metrics output should be `zt_w_d`, `st_(w|wo)_d_(0.25|0.5)`, `mt_(0.25|0.5)`, and `all_(0.25|0.5)`.