### PR TITLE
Add flag to require all GT keys in prediction

### DIFF
--- a/src/torchmetrics_ext/metrics/visual_grounding/__init__.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/__init__.py
@@ -1,5 +1,6 @@
 from .scanrefer import ScanReferMetric
 from .nr3d import Nr3DMetric
 from .multi3drefer import Multi3DReferMetric
+from .vigil3d import ViGiL3DMetric
 
-__all__ = ["ScanReferMetric", "Nr3DMetric", "Multi3DReferMetric"]
+__all__ = ["ScanReferMetric", "Nr3DMetric", "Multi3DReferMetric", "ViGiL3DMetric"]

--- a/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
@@ -1,0 +1,202 @@
+import re
+
+import torch
+import numpy as np
+from tqdm import tqdm
+from typing import Dict
+from torchmetrics import Metric
+from datasets import load_dataset
+from huggingface_hub import hf_hub_download
+from scipy.optimize import linear_sum_assignment
+from torchmetrics_ext.tools import get_aabb_per_pair_ious
+
+
+class ViGiL3DMetric(Metric):
+    r"""
+    Computes F1-scores at multiple IoU thresholds (F1@kIoU) for the ViGiL3D 3D visual grounding benchmark.
+    Predicted and ground truth axis-aligned bounding boxes are compared using the Hungarian matching algorithm based on IoUs.
+
+    Note:
+        - the GT box coordinates are axis-aligned by applying the 4x4 transformation matrix provided in <scene_id>.txt from the ScanNet dataset.
+        - final metrics are computed as averages across the submitted predictions, rather than across the entire dataset.
+
+    References:
+        - ViGiL3DMetric: https://3dlg-hcvc.github.io/vigil3d/
+
+    Example 1:
+        - evaluate all predictions once
+        >>> import torch
+        >>> from torchmetrics_ext.metrics.visual_grounding import ViGiL3DMetric
+        >>> metric = ViGiL3DMetric(split="test")
+        >>> # preds is a dictionary mapping each unique description identifier (formatted as "{scene_id}_{ann_id}")
+        >>> # to a variable number of predicted axis-aligned bounding boxes in shape (N, 2, 3)
+        >>> preds = {
+        ...     "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[0., 0., 0.], [0.5, 0.5, 0.5]]]),  # 1 predicted box
+        ...     "aec1e11f-43c6-4596-8f3a-161880201ef9": torch.tensor([[[0., 0., 0.], [1., 1., 1.]], [[0., 0., 0.], [2., 2., 2.]]]),  # 2 predicted boxes
+        ...     ...
+        ... }
+        >>> result = metric(preds)
+    Example 2:
+        - evaluate predictions in batches with automatic accumulation over batches and synchronization between multiple devices
+        >>> import torch
+        >>> from torchmetrics_ext.metrics.visual_grounding import ViGiL3DMetric
+        >>> metric = ViGiL3DMetric(split="test")
+        >>> preds_batch_1 = {
+        ...     "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[0., 0., 0.], [0.5, 0.5, 0.5]]]),  # 1 predicted box
+        ...     "aec1e11f-43c6-4596-8f3a-161880201ef9": torch.tensor([[[0., 0., 0.], [1., 1., 1.]], [[0., 0., 0.], [2., 2., 2.]]]),  # 2 predicted boxes
+        ...     ...
+        ... }
+        >>> metric.update(preds_batch_1)  # can be called from different devices
+        >>> preds_batch_2 = {
+        ...     "9914bb89-4346-489b-9c0b-65fb3815f06a": torch.tensor([[[0.5, 0.1, 0.], [1.5, 0.5, 0.5]]]),  # 1 predicted box
+        ...     ...
+        ... }
+        >>> metric.update(preds_batch_2)  # can be called from different devices
+        >>> result = metric.compute()
+        >>> metric.reset()  # reset metric state for next evaluation round
+    """
+    iou_thresholds = (0.25, 0.5)
+    eval_types = ("zt", "st", "mt")
+    scene_obj_id_parser = re.compile(r"^(?P<scene_id>.+)_(?P<ann_id>\d+)$")
+
+    def __init__(self, split="validation"):
+        super().__init__()
+
+        # initialize metrics
+        for i, eval_type in enumerate(self.eval_types):
+            self.add_state(name=f"{eval_type}_total", default=torch.tensor(0), dist_reduce_fx="sum")
+
+            for iou_threshold in self.iou_thresholds:
+                self.add_state(
+                    name=f"{eval_type}_f1_thresh_{iou_threshold}", default=torch.tensor(0.), dist_reduce_fx="sum"
+                )
+        for iou_threshold in self.iou_thresholds:
+            self.add_state(name=f"all_f1_thresh_{iou_threshold}", default=torch.tensor(0.), dist_reduce_fx="sum")
+
+        self.add_state(name="all_total", default=torch.tensor(0), dist_reduce_fx="sum")
+
+        # initialize dataset
+        self._load_gt_data(split=split)
+
+    def get_all_data_ids(self):
+        return list(self.gt_data.keys())
+
+    def _load_gt_data(self, split):
+        def load_from_hf(repo_id, filename):
+            scene_metadata_path = hf_hub_download(
+                repo_id=repo_id, filename=filename, repo_type="dataset"
+            )
+            scene_metadata = np.load(scene_metadata_path)
+            scene_ids = set(self.scene_obj_id_parser.search(key).group("scene_id") for key in scene_metadata.keys())
+
+            num_processed = 0
+            for row in tqdm(raw_dataset, desc=f"Preparing evaluation dataset (checking against {repo_id}:{filename})"):
+                if row["scene_id"] not in scene_ids:
+                    continue
+
+                data_id = row["ann_id"]
+                gt_aabbs = []
+                for object_id in row["object_ids"]:
+                    gt_aabbs.append(scene_metadata[f"{row['scene_id']}_{object_id}"])
+                gt_aabbs = np.stack(gt_aabbs) if len(gt_aabbs) > 0 else None
+                
+                num_objects = min(len(row["object_ids"]), 2)
+                eval_type = self.eval_types[num_objects]
+
+                self.gt_data[data_id] = {"gt_aabbs": gt_aabbs, "eval_type": eval_type}
+                num_processed += 1
+            
+            print(f"  Processed {num_processed} rows from {repo_id}:{filename}")
+
+        self.gt_data = {}
+        raw_dataset = load_dataset("3dlg-hcvc/vigil3d", split=split)
+        for spl in ["train", "validation"]:
+            load_from_hf("torchmetrics-ext/metadata", f"scannetv2/obj_aabbs_{spl}.npz")
+            load_from_hf("torchmetrics-ext/metadata", f"scannetpp/obj_aabbs_{spl}.npz")
+
+        # check that all data ids are present
+        for row in raw_dataset:
+            data_id = row["ann_id"]
+            if data_id not in self.gt_data:
+                raise ValueError(f"Data ID {data_id} not found in the ground truth dataset.")
+
+    def _eval_zt(self, pred):
+        f1_score = 1 if len(pred) == 0 else 0
+        f1_scores = {iou_threshold: f1_score for iou_threshold in self.iou_thresholds}
+        return f1_scores
+
+    def _eval_st_or_mt(self, pred, target):
+
+        # initialize the cost matrix
+        square_matrix_len = max(len(target), len(pred))
+        iou_matrix = torch.zeros(size=(square_matrix_len, square_matrix_len), dtype=pred.dtype, device=pred.device)
+
+        # calculate ious for all combinations
+        ious = get_aabb_per_pair_ious(target, pred)
+        iou_matrix[:ious.shape[0], :ious.shape[1]] = ious
+
+        # apply matching algorithm
+        iou_matrix = iou_matrix.cpu().numpy()  # TODO: only have the numpy version now
+        row_idx, col_idx = linear_sum_assignment(iou_matrix * -1)
+
+        matched_ious = iou_matrix[row_idx, col_idx]
+
+        iou_thresholds = np.array(self.iou_thresholds, dtype=np.float32)[:, None]
+
+        tp = (matched_ious >= iou_thresholds).sum(axis=1)
+
+        # calculate f1-scores for each iou threshold
+        f1_scores = 2 * tp / (len(pred) + len(target))
+
+        f1_scores = {iou_threshold: f1_scores[i] for i, iou_threshold in enumerate(self.iou_thresholds)}
+        return f1_scores
+
+    def update(self, preds: Dict[str, torch.Tensor]) -> None:
+        """
+        Processes a batch of predicted results, evaluates them against ground truth, and updates
+        internal F1-score statistics for all IoU thresholds.
+
+        Args:
+            preds (dict):
+            A dictionary mapping each unique description identifier (formatted as "{scene_id}_{ann_id}")
+            to its predicted axis-aligned bounding boxes. Each value is a tensor of shape (N, 2, 3),
+            representing the min and max 3D coordinates for N predicted boxes.
+
+        Example Input:
+            preds = {
+                "scene0011_00_0": torch.tensor([[[0., 0., 0.], [0.5, 0.5, 0.5]]]),
+                "scene0011_01_1": torch.tensor([[[0., 0., 0.], [1., 1., 1.]], [[0., 0., 0.], [2., 2., 2.]]]),
+                ...
+            }
+        """
+        for key, pred_aabbs in preds.items():
+            assert key in self.gt_data, f"id {key} is not in the ground truth dataset"
+            eval_type = self.gt_data[key]["eval_type"]
+            gt_aabbs = self.gt_data[key]["gt_aabbs"]
+
+            if "zt" in eval_type:
+                f1_scores = self._eval_zt(pred_aabbs)
+            elif "st" in eval_type or "mt" in eval_type:
+                f1_scores = self._eval_st_or_mt(pred_aabbs, torch.from_numpy(gt_aabbs))
+            else:
+                raise NotImplementedError
+
+            self.__dict__[f"{eval_type}_total"] += 1
+            self.all_total += 1
+
+            for iou_threshold in self.iou_thresholds:
+                self.__dict__[f"{eval_type}_f1_thresh_{iou_threshold}"] += f1_scores[iou_threshold]
+                self.__dict__[f"all_f1_thresh_{iou_threshold}"] += f1_scores[iou_threshold]
+
+    def compute(self) -> Dict[str, torch.Tensor]:
+        output_dict = {}
+        for iou_threshold in self.iou_thresholds:
+            for eval_type in self.eval_types:
+                output_dict[f"{eval_type}_{iou_threshold}"] = self.__dict__[f"{eval_type}_f1_thresh_{iou_threshold}"] / self.__dict__[f"{eval_type}_total"]
+            output_dict[f"all_{iou_threshold}"] = self.__dict__[f"all_f1_thresh_{iou_threshold}"] / self.all_total
+
+        # clean the zt case since it doesn't have thresholds
+        output_dict[f"zt"] = output_dict["zt_0.25"]
+        del output_dict["zt_0.5"]
+
+        return output_dict

--- a/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
@@ -17,7 +17,8 @@ class ViGiL3DMetric(Metric):
     Predicted and ground truth axis-aligned bounding boxes are compared using the Hungarian matching algorithm based on IoUs.
 
     Note:
-        - the GT box coordinates are axis-aligned by applying the 4x4 transformation matrix provided in <scene_id>.txt from the ScanNet dataset.
+        - ScanNet: the GT box coordinates are axis-aligned by applying the 4x4 transformation matrix provided in <scene_id>.txt from the dataset
+        - ScanNet++: the GT box coordinates are directly from the dataset without applying any additional transformations
         - final metrics are computed as averages across the submitted predictions, rather than across the entire dataset.
 
     References:

--- a/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
@@ -56,11 +56,12 @@ class ViGiL3DMetric(Metric):
         >>> result = metric.compute()
         >>> metric.reset()  # reset metric state for next evaluation round
     """
+
     iou_thresholds = (0.25, 0.5)
     eval_types = ("zt", "st", "mt")
     scene_obj_id_parser = re.compile(r"^(?P<scene_id>.+)_(?P<ann_id>\d+)$")
 
-    def __init__(self, split="validation"):
+    def __init__(self, split: str = "validation", strict: bool = False):
         super().__init__()
 
         # initialize metrics
@@ -69,24 +70,24 @@ class ViGiL3DMetric(Metric):
 
             for iou_threshold in self.iou_thresholds:
                 self.add_state(
-                    name=f"{eval_type}_f1_thresh_{iou_threshold}", default=torch.tensor(0.), dist_reduce_fx="sum"
+                    name=f"{eval_type}_f1_thresh_{iou_threshold}", default=torch.tensor(0.0), dist_reduce_fx="sum"
                 )
         for iou_threshold in self.iou_thresholds:
-            self.add_state(name=f"all_f1_thresh_{iou_threshold}", default=torch.tensor(0.), dist_reduce_fx="sum")
+            self.add_state(name=f"all_f1_thresh_{iou_threshold}", default=torch.tensor(0.0), dist_reduce_fx="sum")
 
         self.add_state(name="all_total", default=torch.tensor(0), dist_reduce_fx="sum")
 
         # initialize dataset
         self._load_gt_data(split=split)
 
+        self.strict = strict
+
     def get_all_data_ids(self):
         return list(self.gt_data.keys())
 
     def _load_gt_data(self, split):
         def load_from_hf(repo_id, filename):
-            scene_metadata_path = hf_hub_download(
-                repo_id=repo_id, filename=filename, repo_type="dataset"
-            )
+            scene_metadata_path = hf_hub_download(repo_id=repo_id, filename=filename, repo_type="dataset")
             scene_metadata = np.load(scene_metadata_path)
             scene_ids = set(self.scene_obj_id_parser.search(key).group("scene_id") for key in scene_metadata.keys())
 
@@ -100,13 +101,13 @@ class ViGiL3DMetric(Metric):
                 for object_id in row["object_ids"]:
                     gt_aabbs.append(scene_metadata[f"{row['scene_id']}_{object_id}"])
                 gt_aabbs = np.stack(gt_aabbs) if len(gt_aabbs) > 0 else None
-                
+
                 num_objects = min(len(row["object_ids"]), 2)
                 eval_type = self.eval_types[num_objects]
 
                 self.gt_data[data_id] = {"gt_aabbs": gt_aabbs, "eval_type": eval_type}
                 num_processed += 1
-            
+
             print(f"  Processed {num_processed} rows from {repo_id}:{filename}")
 
         self.gt_data = {}
@@ -134,7 +135,7 @@ class ViGiL3DMetric(Metric):
 
         # calculate ious for all combinations
         ious = get_aabb_per_pair_ious(target, pred)
-        iou_matrix[:ious.shape[0], :ious.shape[1]] = ious
+        iou_matrix[: ious.shape[0], : ious.shape[1]] = ious
 
         # apply matching algorithm
         iou_matrix = iou_matrix.cpu().numpy()  # TODO: only have the numpy version now
@@ -170,6 +171,9 @@ class ViGiL3DMetric(Metric):
                 ...
             }
         """
+        if self.strict and not set(preds.keys()) == self.gt_data.keys():
+            raise ValueError("Mismatched IDs between predictions and dataset")
+
         for key, pred_aabbs in preds.items():
             assert key in self.gt_data, f"id {key} is not in the ground truth dataset"
             eval_type = self.gt_data[key]["eval_type"]
@@ -193,7 +197,9 @@ class ViGiL3DMetric(Metric):
         output_dict = {}
         for iou_threshold in self.iou_thresholds:
             for eval_type in self.eval_types:
-                output_dict[f"{eval_type}_{iou_threshold}"] = self.__dict__[f"{eval_type}_f1_thresh_{iou_threshold}"] / self.__dict__[f"{eval_type}_total"]
+                output_dict[f"{eval_type}_{iou_threshold}"] = (
+                    self.__dict__[f"{eval_type}_f1_thresh_{iou_threshold}"] / self.__dict__[f"{eval_type}_total"]
+                )
             output_dict[f"all_{iou_threshold}"] = self.__dict__[f"all_f1_thresh_{iou_threshold}"] / self.all_total
 
         # clean the zt case since it doesn't have thresholds

--- a/test/test_multi3drefer.py
+++ b/test/test_multi3drefer.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import torch
 from torchmetrics_ext.metrics.visual_grounding import Multi3DReferMetric
@@ -14,7 +15,8 @@ def test_multi3drefer_metric_low_iou(multi3drefer_metric):
 
     # Test update functionality with dummy data
     preds = {
-        "scene0406_00_6": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 0 predicted boxes
+        "scene0406_00_6": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 0 predicted boxes (w)
+        "scene0578_00_69": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 0 predicted boxes (wo)
         "scene0406_00_0": torch.tensor([[[3.83, 3.04, 4.26], [3.88, 3.47, 4.78]]]),  # 1 predicted box
         "scene0406_00_84": torch.tensor([[[3.40, 3.89, 3.31], [3.71, 3.96, 3.58]]]),  # 1 predicted box
         "scene0406_00_10": torch.tensor([
@@ -45,15 +47,16 @@ def test_multi3drefer_metric_low_iou(multi3drefer_metric):
         ])
     }
     result = multi3drefer_metric(preds)
-    assert result["zt_w_d"].item() == 0.0
-    assert result["st_w_d_0.25"].item() == 0.0
-    assert result["st_wo_d_0.25"].item() == 0.0
-    assert result["st_w_d_0.5"].item() == 0.0
-    assert result["st_wo_d_0.5"].item() == 0.0
-    assert result["mt_0.25"].item() == 0.0
-    assert result["mt_0.5"].item() == 0.0
-    assert result["all_0.25"].item() == 0.0
-    assert result["all_0.5"].item() == 0.0
+    assert torch.allclose(result["zt_w_d"], torch.tensor(0.0))
+    assert torch.allclose(result["zt_wo_d"], torch.tensor(0.0))
+    assert torch.allclose(result["st_w_d_0.25"], torch.tensor(0.0))
+    assert torch.allclose(result["st_wo_d_0.25"], torch.tensor(0.0))
+    assert torch.allclose(result["st_w_d_0.5"], torch.tensor(0.0))
+    assert torch.allclose(result["st_wo_d_0.5"], torch.tensor(0.0))
+    assert torch.allclose(result["mt_0.25"], torch.tensor(0.0))
+    assert torch.allclose(result["mt_0.5"], torch.tensor(0.0))
+    assert torch.allclose(result["all_0.25"], torch.tensor(0.0))
+    assert torch.allclose(result["all_0.5"], torch.tensor(0.0))
 
 
 def test_multi3drefer_metric_medium_iou(multi3drefer_metric):
@@ -61,7 +64,8 @@ def test_multi3drefer_metric_medium_iou(multi3drefer_metric):
 
     # Test update functionality with dummy data
     preds = {
-        "scene0406_00_6": torch.tensor([]),  # 0 predicted boxes
+        "scene0406_00_6": torch.tensor([]),  # 0 predicted boxes (w)
+        "scene0578_00_69": torch.tensor([]),  # 0 predicted boxes (wo)
         "scene0406_00_0": torch.tensor([[[0.855, 0.0380, 1.2593], [0.88, 0.47, 1.78]]]),  # 1 predicted box
         "scene0406_00_84": torch.tensor([[[0.0827, 0.8602, 0.3036], [0.706, 0.964, 0.575]]]),  # 1 predicted box
         "scene0406_00_10": torch.tensor([
@@ -92,15 +96,16 @@ def test_multi3drefer_metric_medium_iou(multi3drefer_metric):
         ])
     }
     result = multi3drefer_metric(preds)
-    assert result["zt_w_d"].item() == 1.0
-    assert result["st_w_d_0.25"].item() == 1.0
-    assert result["st_wo_d_0.25"].item() == 1.0
-    assert result["st_w_d_0.5"].item() == 0.0
-    assert result["st_wo_d_0.5"].item() == 0.0
-    assert result["mt_0.25"].item() == 1.0
-    assert result["mt_0.5"].item() == 0.0
-    assert result["all_0.25"].item() == 1.0
-    assert result["all_0.5"].item() == 0.25  # because zt counts as 1
+    assert torch.allclose(result["zt_w_d"], torch.tensor(1.0))
+    assert torch.allclose(result["zt_wo_d"], torch.tensor(1.0))
+    assert torch.allclose(result["st_w_d_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["st_wo_d_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["st_w_d_0.5"], torch.tensor(0.0))
+    assert torch.allclose(result["st_wo_d_0.5"], torch.tensor(0.0))
+    assert torch.allclose(result["mt_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["mt_0.5"], torch.tensor(0.0))
+    assert torch.allclose(result["all_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["all_0.5"], torch.tensor(0.40))  # because zt counts as 1
 
 
 def test_multi3drefer_metric_high_iou(multi3drefer_metric):
@@ -108,7 +113,8 @@ def test_multi3drefer_metric_high_iou(multi3drefer_metric):
 
     # Test update functionality with dummy data
     preds = {
-        "scene0406_00_6": torch.tensor([]),  # 0 predicted boxes
+        "scene0406_00_6": torch.tensor([]),  # 0 predicted boxes (w)
+        "scene0578_00_69": torch.tensor([]),  # 0 predicted boxes (wo)
         "scene0406_00_0": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 1 predicted box
         "scene0406_00_84": torch.tensor([[[0.40, 0.89, 0.31], [0.71, 0.96, 0.58]]]),  # 1 predicted box
         "scene0406_00_10": torch.tensor([
@@ -139,12 +145,13 @@ def test_multi3drefer_metric_high_iou(multi3drefer_metric):
         ])
     }
     result = multi3drefer_metric(preds)
-    assert result["zt_w_d"].item() == 1.0
-    assert result["st_w_d_0.25"].item() == 1.0
-    assert result["st_wo_d_0.25"].item() == 1.0
-    assert result["st_w_d_0.5"].item() == 1.0
-    assert result["st_wo_d_0.5"].item() == 1.0
-    assert result["mt_0.25"].item() == 1.0
-    assert result["mt_0.5"].item() == 1.0
-    assert result["all_0.25"].item() == 1.0
-    assert result["all_0.5"].item() == 1.0
+    assert torch.allclose(result["zt_w_d"], torch.tensor(1.0))
+    assert torch.allclose(result["zt_wo_d"], torch.tensor(1.0))
+    assert torch.allclose(result["st_w_d_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["st_wo_d_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["st_w_d_0.5"], torch.tensor(1.0))
+    assert torch.allclose(result["st_wo_d_0.5"], torch.tensor(1.0))
+    assert torch.allclose(result["mt_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["mt_0.5"], torch.tensor(1.0))
+    assert torch.allclose(result["all_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["all_0.5"], torch.tensor(1.0))

--- a/test/test_multi3drefer.py
+++ b/test/test_multi3drefer.py
@@ -7,7 +7,12 @@ from torchmetrics_ext.metrics.visual_grounding import Multi3DReferMetric
 # Test for Multi3DReferMetric
 @pytest.fixture
 def multi3drefer_metric():
-    return Multi3DReferMetric(split="validation")
+    return Multi3DReferMetric(split="validation", strict=False)
+
+
+@pytest.fixture
+def multi3drefer_metric_strict():
+    return Multi3DReferMetric(split="validation", strict=True)
 
 
 def test_multi3drefer_metric_low_iou(multi3drefer_metric):
@@ -19,32 +24,9 @@ def test_multi3drefer_metric_low_iou(multi3drefer_metric):
         "scene0578_00_69": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 0 predicted boxes (wo)
         "scene0406_00_0": torch.tensor([[[3.83, 3.04, 4.26], [3.88, 3.47, 4.78]]]),  # 1 predicted box
         "scene0406_00_84": torch.tensor([[[3.40, 3.89, 3.31], [3.71, 3.96, 3.58]]]),  # 1 predicted box
-        "scene0406_00_10": torch.tensor([
-            [
-                [
-                    -3.01,
-                    -3.26,
-                    3.034
-                ],
-                [
-                    -2.54,
-                    -3.03,
-                    4.91
-                ]
-            ],
-            [
-                [
-                    -3.43,
-                    -3.32,
-                    4.23
-                ],
-                [
-                    -2.96,
-                    -2.89,
-                    4.71
-                ]
-            ]
-        ])
+        "scene0406_00_10": torch.tensor(
+            [[[-3.01, -3.26, 3.034], [-2.54, -3.03, 4.91]], [[-3.43, -3.32, 4.23], [-2.96, -2.89, 4.71]]]
+        ),
     }
     result = multi3drefer_metric(preds)
     assert torch.allclose(result["zt_w_d"], torch.tensor(0.0))
@@ -68,32 +50,9 @@ def test_multi3drefer_metric_medium_iou(multi3drefer_metric):
         "scene0578_00_69": torch.tensor([]),  # 0 predicted boxes (wo)
         "scene0406_00_0": torch.tensor([[[0.855, 0.0380, 1.2593], [0.88, 0.47, 1.78]]]),  # 1 predicted box
         "scene0406_00_84": torch.tensor([[[0.0827, 0.8602, 0.3036], [0.706, 0.964, 0.575]]]),  # 1 predicted box
-        "scene0406_00_10": torch.tensor([
-            [
-                [
-                    -0.2018,
-                    -0.3002,
-                    0.0238
-                ],
-                [
-                    0.46,
-                    0.03,
-                    1.91
-                ]
-            ],
-            [
-                [
-                    -0.43,
-                    -0.32,
-                    1.525
-                ],
-                [
-                    0.04,
-                    -0.11,
-                    1.71
-                ]
-            ]
-        ])
+        "scene0406_00_10": torch.tensor(
+            [[[-0.2018, -0.3002, 0.0238], [0.46, 0.03, 1.91]], [[-0.43, -0.32, 1.525], [0.04, -0.11, 1.71]]]
+        ),
     }
     result = multi3drefer_metric(preds)
     assert torch.allclose(result["zt_w_d"], torch.tensor(1.0))
@@ -117,32 +76,9 @@ def test_multi3drefer_metric_high_iou(multi3drefer_metric):
         "scene0578_00_69": torch.tensor([]),  # 0 predicted boxes (wo)
         "scene0406_00_0": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 1 predicted box
         "scene0406_00_84": torch.tensor([[[0.40, 0.89, 0.31], [0.71, 0.96, 0.58]]]),  # 1 predicted box
-        "scene0406_00_10": torch.tensor([
-            [
-                [
-                    -0.01,
-                    -0.26,
-                    0.034
-                ],
-                [
-                    0.46,
-                    -0.03,
-                    1.91
-                ]
-            ],
-            [
-                [
-                    -0.43,
-                    -0.32,
-                    1.23
-                ],
-                [
-                    0.04,
-                    -0.11,
-                    1.71
-                ]
-            ]
-        ])
+        "scene0406_00_10": torch.tensor(
+            [[[-0.01, -0.26, 0.034], [0.46, -0.03, 1.91]], [[-0.43, -0.32, 1.23], [0.04, -0.11, 1.71]]]
+        ),
     }
     result = multi3drefer_metric(preds)
     assert torch.allclose(result["zt_w_d"], torch.tensor(1.0))
@@ -155,3 +91,32 @@ def test_multi3drefer_metric_high_iou(multi3drefer_metric):
     assert torch.allclose(result["mt_0.5"], torch.tensor(1.0))
     assert torch.allclose(result["all_0.25"], torch.tensor(1.0))
     assert torch.allclose(result["all_0.5"], torch.tensor(1.0))
+
+
+def test_multi3drefer_metric_strict_mode(multi3drefer_metric_strict: Multi3DReferMetric):
+    # Test with missing predictions
+    gt_data = multi3drefer_metric_strict.gt_data
+    preds = {key: torch.from_numpy(data["gt_aabbs"]) if data["gt_aabbs"] is not None else torch.tensor([]) for key, data in gt_data.items()}
+
+    result = multi3drefer_metric_strict(preds)
+    assert torch.allclose(result["zt_w_d"], torch.tensor(1.0))
+    assert torch.allclose(result["zt_wo_d"], torch.tensor(1.0))
+    assert torch.allclose(result["st_w_d_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["st_wo_d_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["st_w_d_0.5"], torch.tensor(1.0))
+    assert torch.allclose(result["st_wo_d_0.5"], torch.tensor(1.0))
+    assert torch.allclose(result["mt_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["mt_0.5"], torch.tensor(1.0))
+    assert torch.allclose(result["all_0.25"], torch.tensor(1.0))
+    assert torch.allclose(result["all_0.5"], torch.tensor(1.0))
+
+
+def test_multi3drefer_metric_strict_mode_missing_samples(multi3drefer_metric_strict: Multi3DReferMetric):
+    preds = {
+        "scene0406_00_6": torch.tensor([]),  # 0 predicted boxes (w)
+        "scene0578_00_69": torch.tensor([]),  # 0 predicted boxes (wo)
+        "scene0406_00_0": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 1 predicted box
+        "scene0406_00_84": torch.tensor([[[0.40, 0.89, 0.31], [0.71, 0.96, 0.58]]]),  # 1 predicted box
+    }
+    with pytest.raises(ValueError, match="Mismatched IDs between predictions and dataset"):
+        multi3drefer_metric_strict(preds)

--- a/test/test_vigil3d.py
+++ b/test/test_vigil3d.py
@@ -9,23 +9,28 @@ def vigil3d_metric():
     return ViGiL3DMetric(split="validation")
 
 
+@pytest.fixture
+def vigil3d_metric_strict():
+    return ViGiL3DMetric(split="validation", strict=True)
+
+
 def test_vigil3d_metric_low_iou(vigil3d_metric):
     vigil3d_metric.reset()  # Reset the metric before testing
 
     # Test update functionality with dummy data
     preds = {
-        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 0 predicted boxes
-        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[4.41, 4.13, 3.016], [4.54, 5.31, 4.60]]]),  # 1 predicted box
-        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor([
+        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor(
+            [[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]
+        ),  # 0 predicted boxes
+        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+            [[[4.41, 4.13, 3.016], [4.54, 5.31, 4.60]]]
+        ),  # 1 predicted box
+        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
             [
-                [3.02576269, 4.627958  , 4.19777474],
-                [3.50918661, 5.06877917, 4.49572316]
-            ],
-            [
-                [5.10415515, 4.19511597, 3.43203823],
-                [5.54735444, 4.75973447, 3.76923387]
+                [[3.02576269, 4.627958, 4.19777474], [3.50918661, 5.06877917, 4.49572316]],
+                [[5.10415515, 4.19511597, 3.43203823], [5.54735444, 4.75973447, 3.76923387]],
             ]
-        ])
+        ),
     }
     result = vigil3d_metric(preds)
     assert result["zt"].item() == 0.0
@@ -43,17 +48,15 @@ def test_vigil3d_metric_medium_iou(vigil3d_metric):
     # Test update functionality with dummy data
     preds = {
         "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
-        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[1.48, 1.13, 0.016], [1.61, 2.31, 1.60]]]),  # 1 predicted box
-        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor([
+        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+            [[[1.48, 1.13, 0.016], [1.61, 2.31, 1.60]]]
+        ),  # 1 predicted box
+        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
             [
-                [0.03576269, 1.627958  , 1.19777474],
-                [0.51918661, 2.06877917, 1.49572316]
-            ],
-            [
-                [2.32415515, 1.19511597, 0.43203823],
-                [2.74735444, 1.75973447, 0.76923387]
+                [[0.03576269, 1.627958, 1.19777474], [0.51918661, 2.06877917, 1.49572316]],
+                [[2.32415515, 1.19511597, 0.43203823], [2.74735444, 1.75973447, 0.76923387]],
             ]
-        ])
+        ),
     }
     result = vigil3d_metric(preds)
     assert result["zt"].item() == 1.0
@@ -71,17 +74,15 @@ def test_vigil3d_metric_high_iou(vigil3d_metric):
     # Test update functionality with dummy data
     preds = {
         "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
-        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[1.41, 1.13, 0.016], [1.54, 2.31, 1.60]]]),  # 1 predicted box
-        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor([
+        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+            [[[1.41, 1.13, 0.016], [1.54, 2.31, 1.60]]]
+        ),  # 1 predicted box
+        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
             [
-                [0.02576269, 1.627958  , 1.19777474],
-                [0.50918661, 2.06877917, 1.49572316]
-            ],
-            [
-                [2.10415515, 1.19511597, 0.43203823],
-                [2.54735444, 1.75973447, 0.76923387]
+                [[0.02576269, 1.627958, 1.19777474], [0.50918661, 2.06877917, 1.49572316]],
+                [[2.10415515, 1.19511597, 0.43203823], [2.54735444, 1.75973447, 0.76923387]],
             ]
-        ])
+        ),
     }
     result = vigil3d_metric(preds)
     assert result["zt"].item() == 1.0
@@ -91,3 +92,32 @@ def test_vigil3d_metric_high_iou(vigil3d_metric):
     assert result["mt_0.5"].item() == 1.0
     assert result["all_0.25"].item() == 1.0
     assert result["all_0.5"].item() == 1.0
+
+
+def test_vigil3d_metric_strict_mode(vigil3d_metric_strict: ViGiL3DMetric):
+    # Test with missing predictions
+    gt_data = vigil3d_metric_strict.gt_data
+    preds = {
+        key: torch.from_numpy(data["gt_aabbs"]) if data["gt_aabbs"] is not None else torch.tensor([])
+        for key, data in gt_data.items()
+    }
+
+    result = vigil3d_metric_strict(preds)
+    assert result["zt"].item() == 1.0
+    assert result["st_0.25"].item() == 1.0
+    assert result["st_0.5"].item() == 1.0
+    assert result["mt_0.25"].item() == 1.0
+    assert result["mt_0.5"].item() == 1.0
+    assert result["all_0.25"].item() == 1.0
+    assert result["all_0.5"].item() == 1.0
+
+
+def test_vigil3d_metric_strict_mode_missing_samples(vigil3d_metric_strict: ViGiL3DMetric):
+    preds = {
+        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
+        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+            [[[1.41, 1.13, 0.016], [1.54, 2.31, 1.60]]]
+        ),  # 1 predicted box
+    }
+    with pytest.raises(ValueError, match="Mismatched IDs between predictions and dataset"):
+        vigil3d_metric_strict(preds)

--- a/test/test_vigil3d.py
+++ b/test/test_vigil3d.py
@@ -1,0 +1,93 @@
+import pytest
+import torch
+from torchmetrics_ext.metrics.visual_grounding import ViGiL3DMetric
+
+
+# Test for Multi3DReferMetric
+@pytest.fixture
+def vigil3d_metric():
+    return ViGiL3DMetric(split="validation")
+
+
+def test_vigil3d_metric_low_iou(vigil3d_metric):
+    vigil3d_metric.reset()  # Reset the metric before testing
+
+    # Test update functionality with dummy data
+    preds = {
+        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]),  # 0 predicted boxes
+        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[4.41, 4.13, 3.016], [4.54, 5.31, 4.60]]]),  # 1 predicted box
+        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor([
+            [
+                [3.02576269, 4.627958  , 4.19777474],
+                [3.50918661, 5.06877917, 4.49572316]
+            ],
+            [
+                [5.10415515, 4.19511597, 3.43203823],
+                [5.54735444, 4.75973447, 3.76923387]
+            ]
+        ])
+    }
+    result = vigil3d_metric(preds)
+    assert result["zt"].item() == 0.0
+    assert result["st_0.25"].item() == 0.0
+    assert result["st_0.5"].item() == 0.0
+    assert result["mt_0.25"].item() == 0.0
+    assert result["mt_0.5"].item() == 0.0
+    assert result["all_0.25"].item() == 0.0
+    assert result["all_0.5"].item() == 0.0
+
+
+def test_vigil3d_metric_medium_iou(vigil3d_metric):
+    vigil3d_metric.reset()  # Reset the metric before testing
+
+    # Test update functionality with dummy data
+    preds = {
+        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
+        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[1.48, 1.13, 0.016], [1.61, 2.31, 1.60]]]),  # 1 predicted box
+        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor([
+            [
+                [0.03576269, 1.627958  , 1.19777474],
+                [0.51918661, 2.06877917, 1.49572316]
+            ],
+            [
+                [2.32415515, 1.19511597, 0.43203823],
+                [2.74735444, 1.75973447, 0.76923387]
+            ]
+        ])
+    }
+    result = vigil3d_metric(preds)
+    assert result["zt"].item() == 1.0
+    assert result["st_0.25"].item() == 1.0
+    assert result["st_0.5"].item() == 0.0
+    assert result["mt_0.25"].item() == 1.0
+    assert result["mt_0.5"].item() == 0.5
+    assert result["all_0.25"].item() == 1.0
+    assert result["all_0.5"].item() == 0.5
+
+
+def test_multi3drefer_metric_high_iou(vigil3d_metric):
+    vigil3d_metric.reset()  # Reset the metric before testing
+
+    # Test update functionality with dummy data
+    preds = {
+        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
+        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor([[[1.41, 1.13, 0.016], [1.54, 2.31, 1.60]]]),  # 1 predicted box
+        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor([
+            [
+                [0.02576269, 1.627958  , 1.19777474],
+                [0.50918661, 2.06877917, 1.49572316]
+            ],
+            [
+                [2.10415515, 1.19511597, 0.43203823],
+                [2.54735444, 1.75973447, 0.76923387]
+            ]
+        ])
+    }
+    result = vigil3d_metric(preds)
+    assert result["zt"].item() == 1.0
+    assert result["st_0.25"].item() == 1.0
+    assert result["st_0.5"].item() == 1.0
+    assert result["mt_0.25"].item() == 1.0
+    assert result["mt_0.5"].item() == 1.0
+    assert result["all_0.25"].item() == 1.0
+    assert result["all_0.5"].item() == 1.0

--- a/test/test_vigil3d.py
+++ b/test/test_vigil3d.py
@@ -3,7 +3,7 @@ import torch
 from torchmetrics_ext.metrics.visual_grounding import ViGiL3DMetric
 
 
-# Test for Multi3DReferMetric
+# Test for ViGiL3DMetric
 @pytest.fixture
 def vigil3d_metric():
     return ViGiL3DMetric(split="validation")

--- a/test/test_vigil3d.py
+++ b/test/test_vigil3d.py
@@ -65,7 +65,7 @@ def test_vigil3d_metric_medium_iou(vigil3d_metric):
     assert result["all_0.5"].item() == 0.5
 
 
-def test_multi3drefer_metric_high_iou(vigil3d_metric):
+def test_vigil3d_metric_high_iou(vigil3d_metric):
     vigil3d_metric.reset()  # Reset the metric before testing
 
     # Test update functionality with dummy data


### PR DESCRIPTION
# Change Log

* Add `strict` flag to `Multi3DReferMetric` and `ViGiL3DMetric` to require all predictions to be present in metric calculation