### PR TITLE
Adjust IDs for ViGiL3D to scene_id + ann_id

### DIFF
--- a/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
+++ b/src/torchmetrics_ext/metrics/visual_grounding/vigil3d.py
@@ -96,7 +96,7 @@ class ViGiL3DMetric(Metric):
                 if row["scene_id"] not in scene_ids:
                     continue
 
-                data_id = row["ann_id"]
+                data_id = f"{row['scene_id']}_{row['ann_id']}"
                 gt_aabbs = []
                 for object_id in row["object_ids"]:
                     gt_aabbs.append(scene_metadata[f"{row['scene_id']}_{object_id}"])
@@ -118,7 +118,7 @@ class ViGiL3DMetric(Metric):
 
         # check that all data ids are present
         for row in raw_dataset:
-            data_id = row["ann_id"]
+            data_id = f"{row['scene_id']}_{row['ann_id']}"
             if data_id not in self.gt_data:
                 raise ValueError(f"Data ID {data_id} not found in the ground truth dataset.")
 

--- a/test/test_vigil3d.py
+++ b/test/test_vigil3d.py
@@ -19,13 +19,13 @@ def test_vigil3d_metric_low_iou(vigil3d_metric):
 
     # Test update functionality with dummy data
     preds = {
-        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor(
+        "scene0035_00_ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor(
             [[[0.83, 0.04, 1.26], [0.88, 0.47, 1.78]]]
         ),  # 0 predicted boxes
-        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+        "scene0012_00_cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
             [[[4.41, 4.13, 3.016], [4.54, 5.31, 4.60]]]
         ),  # 1 predicted box
-        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
+        "4ea827f5a1_239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
             [
                 [[3.02576269, 4.627958, 4.19777474], [3.50918661, 5.06877917, 4.49572316]],
                 [[5.10415515, 4.19511597, 3.43203823], [5.54735444, 4.75973447, 3.76923387]],
@@ -47,11 +47,11 @@ def test_vigil3d_metric_medium_iou(vigil3d_metric):
 
     # Test update functionality with dummy data
     preds = {
-        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
-        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+        "scene0035_00_ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
+        "scene0012_00_cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
             [[[1.48, 1.13, 0.016], [1.61, 2.31, 1.60]]]
         ),  # 1 predicted box
-        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
+        "4ea827f5a1_239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
             [
                 [[0.03576269, 1.627958, 1.19777474], [0.51918661, 2.06877917, 1.49572316]],
                 [[2.32415515, 1.19511597, 0.43203823], [2.74735444, 1.75973447, 0.76923387]],
@@ -73,11 +73,11 @@ def test_vigil3d_metric_high_iou(vigil3d_metric):
 
     # Test update functionality with dummy data
     preds = {
-        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
-        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+        "scene0035_00_ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
+        "scene0012_00_cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
             [[[1.41, 1.13, 0.016], [1.54, 2.31, 1.60]]]
         ),  # 1 predicted box
-        "239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
+        "4ea827f5a1_239b1e39-7080-49bf-8663-9728613ea770": torch.tensor(
             [
                 [[0.02576269, 1.627958, 1.19777474], [0.50918661, 2.06877917, 1.49572316]],
                 [[2.10415515, 1.19511597, 0.43203823], [2.54735444, 1.75973447, 0.76923387]],
@@ -114,8 +114,8 @@ def test_vigil3d_metric_strict_mode(vigil3d_metric_strict: ViGiL3DMetric):
 
 def test_vigil3d_metric_strict_mode_missing_samples(vigil3d_metric_strict: ViGiL3DMetric):
     preds = {
-        "ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
-        "cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
+        "scene0035_00_ebbbcde5-a9ef-4ab7-9be3-e9f997c3f914": torch.tensor([]),  # 0 predicted boxes
+        "scene0012_00_cf49717d-a751-417e-be93-32fa6a4aa1e4": torch.tensor(
             [[[1.41, 1.13, 0.016], [1.54, 2.31, 1.60]]]
         ),  # 1 predicted box
     }


### PR DESCRIPTION
# Change Log

- Change annotation IDs for `ViGiL3DMetric` to `"{scene_id}_{ann_id}"` to align with `Multi3DReferMetric`